### PR TITLE
feat: Change the logic of environment variables to be injected only a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "ng test",
     "git:save": "git add . && git commit -m 'update: Auto save changes' && git push",
     "git:feature": "git add . && git commit -m 'feat: ' && git push",
-    "git:fix": "git add . && git commit -m 'fix: ' && git push"
+    "git:fix": "git add . && git commit -m 'fix: ' && git push",
+    "vercel-build": "set-env.sh && ng build --configuration production "
   },
   "prettier": {
     "overrides": [

--- a/set-env.sh
+++ b/set-env.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+ENV_FILE="src/environments/firebase.config.prod.ts"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "$ENV_FILE not found!"
+  exit 1
+fi
+
+VARS=$(grep -o '#{[^}]*}#' "$ENV_FILE" | sed 's/[#{}]//g')
+
+for VAR in $VARS; do
+  VALUE=$(eval echo \$$VAR)
+  if [ -z "$VALUE" ]; then
+    echo "Variable $VAR not defined"
+  else
+    sed -i "s|#{$VAR}#|$VALUE|g" "$ENV_FILE"
+    echo "replaced #{$VAR}# by $VALUE"
+  fi
+done

--- a/src/environments/firebase.config.prod.ts
+++ b/src/environments/firebase.config.prod.ts
@@ -1,10 +1,12 @@
-// Firebase configuration for production deployment
+//Consider putting the name of your environment variables in the values ​​between the curly braces.
+
+//Example: #{Your Environment Variable Name}#
 export const firebaseConfig = {
-  apiKey: "AIzaSyCxBU_2x0yEUJrtCdYCBQrttGE3uIk7wK0",
-  authDomain: "ttdn-store.firebaseapp.com",
-  projectId: "ttdn-store", 
-  storageBucket: "ttdn-store.firebasestorage.app",
-  messagingSenderId: "356198567995",
-  appId: "1:356198567995:web:d9608b2e1bf426bf15cc1e",
-  measurementId: "G-LNNHFSDH5C"
+  apiKey: "#{apiKey}#",
+  authDomain: "#{authDomain}#",
+  projectId: "#{projectId}#",
+  storageBucket: "#{storageBucket}#",
+  messagingSenderId: "#{senderId}#",
+  appId: "#{appId}#",
+  measurementId: "#{measurement}#"
 };

--- a/src/environments/firebase.config.ts
+++ b/src/environments/firebase.config.ts
@@ -1,10 +1,12 @@
-// Firebase configuration for TTDN-3 Store
+//Consider putting the name of your environment variables in the values ​​between the curly braces.
+
+//Example: #{Your Environment Variable Name}#
 export const firebaseConfig = {
-  apiKey: "AIzaSyCxBU_2x0yEUJrtCdYCBQrttGE3uIk7wK0",
-  authDomain: "ttdn-store.firebaseapp.com",
-  projectId: "ttdn-store",
-  storageBucket: "ttdn-store.firebasestorage.app",
-  messagingSenderId: "356198567995",
-  appId: "1:356198567995:web:d9608b2e1bf426bf15cc1e",
-  measurementId: "G-LNNHFSDH5C"
-}; 
+  apiKey: "#{apiKey}#",
+  authDomain: "#{authDomain}#",
+  projectId: "#{projectId}#",
+  storageBucket: "#{storageBucket}#",
+  messagingSenderId: "#{senderId}#",
+  appId: "#{appId}#",
+  measurementId: "#{measurement}#"
+};


### PR DESCRIPTION
Hi! I saw that your environment variables are exposed in your repository... this is quite annoying in Angular, considering we don't have a .env file, for example, lol. I made these changes, in case you want to apply them. You'll need to call this vercel-build script I left as an example in the JSON. This is only for your published/production environment, so make sure to define the names in curly braces as the names of your Vercel environment variables.
For local use, I recommend creating something like firebase.config.dev.ts and marking it in gitignore, then you could configure something in angular.json to perform fileReplacement when you use the development configuration.
In my PR example, I left firebase.config.prod.ts, but if you are using firebase.config.ts, you can replace it too!
I really hope this helps. :)